### PR TITLE
hotfix-redirect-indeseado

### DIFF
--- a/src/api/authAPI.js
+++ b/src/api/authAPI.js
@@ -117,7 +117,7 @@ client.interceptors.response.use((response) => {
   const originalRequest = error.config;
 
   if (!originalRequest._retry && 
-      (error.reponse === undefined || error.response.status === 403 || error.response.status === 401) &&
+      (error.response === undefined || error.response.status === 403 || error.response.status === 401) &&
       !window.location.pathname.includes('login') && !window.location.pathname.includes('logout')
     ) {
     // Check if it's the refresh endpoint

--- a/src/views/RecoveryPasswd.jsx
+++ b/src/views/RecoveryPasswd.jsx
@@ -20,6 +20,7 @@ export default function RecoveryPasswd() {
   const [warningSnackbar, setWarningSnackbar] = React.useState(false);
   const [errorSnackbar, setErrorSnackbar] = React.useState(false);
   const [successSnackbar, setSuccessSnackbar] = React.useState(false);
+  const [errorSnackbarText, setErrorSnackbarText] = React.useState("Credenciales inválidas, vuelva a intentarlo a contacto con administración.")
   const navigate = useNavigate();
   const [formData, setFormData] = React.useState({
     email: '',
@@ -66,12 +67,16 @@ export default function RecoveryPasswd() {
         setSuccessSnackbar(true);
         setTimeout(() => {
           navigate("/login");
-        }, 2000);
+        }, 1500);
       })
       .catch((error) => {
+        console.log(error)
+        console.log(error.response.data.message)
+        if(error.response && 'data' in error.response && 'message' in error.response.data ) {
+          setErrorSnackbarText(error.response.data.message)
+        }
         setErrorSnackbar(true);
         setIsLoading(false);
-        window.location.reload();
       })
   };
 
@@ -97,14 +102,14 @@ export default function RecoveryPasswd() {
           onClose={handleSnackbarClose}
           message="Por favor, completa todos los campos."
           severity="warning"
-          duration={1000}
+          duration={2000}
         />
         <CustomSnackbar
           open={errorSnackbar}
           onClose={handleSnackbarClose}
-          message="Error al realizar el inicio de sesión."
+          message={errorSnackbarText}
           severity="error"
-          duration={1000}
+          duration={2000}
         />
         <CustomSnackbar
           open={successSnackbar}

--- a/src/views/SignInSide.jsx
+++ b/src/views/SignInSide.jsx
@@ -74,12 +74,7 @@ export default function Login() {
 
       // Si el parámetro next está definido, se hace le redirect allí,
       // de lo contrario se hace el redirect a "home"
-      // const redirectTo = next ? next : "/";
-      const myRedirect = next === "/recoveryCredentials" ? "/" : "/";
-      console.log("NEXT",next);
-      console.log("MYREDIRECT",myRedirect);
-      const redirectTo = myRedirect ? "/" : next;
-      console.log("REDIRECT", redirectTo);
+      const redirectTo = next ? next : "/";
 
       // navigate(redirectTo);
       setSuccessSnackbar(true);
@@ -87,7 +82,7 @@ export default function Login() {
       setTimeout(() => {
         setSuccessSnackbar(false);
         navigate(redirectTo);
-      }, 3000);
+      }, 1500);
     }
   };
 
@@ -127,6 +122,8 @@ export default function Login() {
   };
 
   const handleRecoveryPasswd = (event) => {
+    // Suspendemos el evento para evitar submits erroneos
+    event.preventDefault();
     navigate("/recoveryCredentials");
   };
 


### PR DESCRIPTION
- Solucionar el problema de los redirect indeseados en la pantalla de recovery
- Quitar el # de la pantalla de recovery al hacer click en login
- Agregar el mensaje de error del backend en la respuesta del snackbar de recovery
- Los redirect con timeout no deberían ser más largos de 1.5 segundos para que sea más fluido
- Los mensajes de error no deberían durar menos de 2 segundos